### PR TITLE
:lock: Update diff to 4.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3936,9 +3936,9 @@
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="
     },
     "dir-glob": {
       "version": "3.0.1",


### PR DESCRIPTION
## Summary
- update transitive `diff` from 4.0.2 to 4.0.4 in the existing npm v1 lockfile
- fix GHSA-73rr-hh4g-fpgx without Dependabot's unrelated 30,000-line lockfile-format migration
- supersede #4 with the same security update as a minimal maintainer-owned change

## Test plan
- `npm ci`
- `npm ls diff --all` (resolves only `diff@4.0.4`)
- `npm audit --json` (the `diff` finding is gone; unrelated legacy findings remain)
- `npm run demo` (24 HTML pages generated)
- `npm pack --dry-run`
- `git diff --check`
